### PR TITLE
Update Highstock version from 1.3.9 to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>highstock</artifactId>
-    <version>1.3.10-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
     <name>Highstock</name>
     <description>WebJar for Highstock</description>
     <url>http://webjars.org</url>
@@ -47,8 +47,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <highstock.version>1.3.9</highstock.version>
-        <highstock.sourceUrl>http://code.highcharts.com/zips/</highstock.sourceUrl> 
+        <highstock.version>2.0.3</highstock.version>
+        <highstock.sourceUrl>https://github.com/highslide-software/highstock-release/archive</highstock.sourceUrl> 
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${highstock.version}</destDir>
     </properties>
 
@@ -64,7 +64,7 @@
                         <goals><goal>download-single</goal></goals>
                         <configuration>
                             <url>${highstock.sourceUrl}</url>
-                            <fromFile>Highstock-${highstock.version}.zip</fromFile>
+                            <fromFile>v${highstock.version}.zip</fromFile>
                             <toFile>${project.build.directory}/highstock.zip</toFile>
                         </configuration>
                     </execution>
@@ -82,8 +82,8 @@
                                 <echo message="unzip archive" />
                                 <unzip src="${project.build.directory}/highstock.zip" dest="${project.build.directory}" />
                                 <echo message="moving resources" />
-                                <move todir="${destDir}/js">
-                                    <fileset dir="${project.build.directory}/js" />
+                                <move todir="${destDir}">
+                                    <fileset dir="${project.build.directory}/highstock-release-${highstock.version}" />
                                 </move>
                             </target>
                         </configuration>


### PR DESCRIPTION
- Updated the link to Highstock releases, since `http://code.highcharts.com/zips/` is not accessible anymore,
- Updated Highstock from 1.3.9 to 2.0.3,
- Changed the destination path from `webjars/highstock/<version>/js/` to the standart `webjars/highstock/<version>/`.
